### PR TITLE
Replace rustc attributes with alternative names

### DIFF
--- a/crates/driver/src/dimanalysis.rs
+++ b/crates/driver/src/dimanalysis.rs
@@ -11,11 +11,11 @@ use syntax::codemap::Span;
 use std;
 use std::collections::{HashMap, HashSet};
 
-const YAOIOUM_ATTR_CHECK_UNIFY: &'static str = "rustc_yaiouom_check_unify";
-const YAOIOUM_ATTR_COMBINATOR_MUL: &'static str = "rustc_yaiouom_combinator_mul";
-const YAOIOUM_ATTR_COMBINATOR_INV: &'static str = "rustc_yaiouom_combinator_inv";
+const YAOIOUM_ATTR_CHECK_UNIFY: &'static str = "yaiouom_check_unify";
+const YAOIOUM_ATTR_COMBINATOR_MUL: &'static str = "yaiouom_combinator_mul";
+const YAOIOUM_ATTR_COMBINATOR_INV: &'static str = "yaiouom_combinator_inv";
 const YAOIOUM_ATTR_COMBINATOR_DIMENSIONLESS: &'static str =
-    "rustc_yaiouom_combinator_dimensionless";
+    "yaiouom_combinator_dimensionless";
 
 /// If this def-id is a "primary tables entry", returns `Some((body_id, decl))`
 /// with information about it's body-id and fn-decl (if any). Otherwise,

--- a/crates/yaiouom/src/unit.rs
+++ b/crates/yaiouom/src/unit.rs
@@ -67,7 +67,7 @@ impl<T: BaseUnit> Unit for T {
 
 /// A value with a unit.
 #[allow(unused_attributes)]
-#[rustc_yaiouom_check_unify_measure]
+#[yaiouom_check_unify_measure]
 pub struct Measure<T, U: Unit> {
     value: T,
     unit: PhantomData<U>,
@@ -158,7 +158,7 @@ impl<T, U: Unit> Measure<T, U> {
     /// As a fallback, **in debug builds**, each call to `unify` will panic
     /// if type `V` is not equivalent ot type `U`.
     #[allow(unused_attributes)]
-    #[rustc_yaiouom_check_unify]
+    #[yaiouom_check_unify]
     pub fn unify<V: Unit>(self) -> Measure<T, V> {
         // First, ensure that we can perform conversion.
         debug_assert_eq!(U::as_runtime(), V::as_runtime());
@@ -563,7 +563,7 @@ impl RuntimeUnit {
 
 /// A unit without dimension.
 #[allow(unused_attributes)]
-#[rustc_yaiouom_combinator_dimensionless]
+#[yaiouom_combinator_dimensionless]
 pub struct Dimensionless;
 impl Unit for Dimensionless {
     fn add_to_runtime(_: &mut RuntimeUnit, _: bool) {
@@ -593,7 +593,7 @@ impl<T> Measure<T, Dimensionless> {
 /// See the documentation of [unify](struct.Measure.html#method.unify) for details
 /// on how to work around this limitation.
 #[allow(unused_attributes)]
-#[rustc_yaiouom_combinator_mul]
+#[yaiouom_combinator_mul]
 pub struct Mul<A, B>
 where
     A: Unit,
@@ -618,7 +618,7 @@ impl<A: Unit, B: Unit> Unit for Mul<A, B> {
 /// See the documentation of [unify](struct.Measure.html#method.unify) for details
 /// on how to work around this limitation.
 #[allow(unused_attributes)]
-#[rustc_yaiouom_combinator_inv]
+#[yaiouom_combinator_inv]
 pub struct Inv<A>
 where
     A: Unit,


### PR DESCRIPTION
Replace attributes starting with `rustc` with alternative names in `crates/driver/src/dimanalysis.rs` and `crates/yaiouom/src/unit.rs`.

* **crates/driver/src/dimanalysis.rs**
  - Replace `rustc_yaiouom_check_unify` with `yaiouom_check_unify`
  - Replace `rustc_yaiouom_combinator_mul` with `yaiouom_combinator_mul`
  - Replace `rustc_yaiouom_combinator_inv` with `yaiouom_combinator_inv`
  - Replace `rustc_yaiouom_combinator_dimensionless` with `yaiouom_combinator_dimensionless`

* **crates/yaiouom/src/unit.rs**
  - Replace `rustc_yaiouom_check_unify_measure` with `yaiouom_check_unify_measure`
  - Replace `rustc_yaiouom_check_unify` with `yaiouom_check_unify`
  - Replace `rustc_yaiouom_combinator_dimensionless` with `yaiouom_combinator_dimensionless`
  - Replace `rustc_yaiouom_combinator_mul` with `yaiouom_combinator_mul`
  - Replace `rustc_yaiouom_combinator_inv` with `yaiouom_combinator_inv`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yoric/yaiouom?shareId=XXXX-XXXX-XXXX-XXXX).